### PR TITLE
Support round-tripping of servlet requests and responses

### DIFF
--- a/src/main/java/io/jenkins/servlet/ServletRequestWrapper.java
+++ b/src/main/java/io/jenkins/servlet/ServletRequestWrapper.java
@@ -17,387 +17,426 @@ import javax.servlet.ServletResponse;
 
 public class ServletRequestWrapper {
     public static jakarta.servlet.ServletRequest toJakartaServletRequest(ServletRequest from) {
-        Objects.requireNonNull(from);
-        return new jakarta.servlet.ServletRequest() {
-            @Override
-            public Object getAttribute(String name) {
-                return from.getAttribute(name);
-            }
-
-            @Override
-            public Enumeration<String> getAttributeNames() {
-                return from.getAttributeNames();
-            }
-
-            @Override
-            public String getCharacterEncoding() {
-                return from.getCharacterEncoding();
-            }
-
-            @Override
-            public void setCharacterEncoding(String env) throws UnsupportedEncodingException {
-                from.setCharacterEncoding(env);
-            }
-
-            @Override
-            public int getContentLength() {
-                return from.getContentLength();
-            }
-
-            @Override
-            public long getContentLengthLong() {
-                return from.getContentLengthLong();
-            }
-
-            @Override
-            public String getContentType() {
-                return from.getContentType();
-            }
-
-            @Override
-            public jakarta.servlet.ServletInputStream getInputStream() throws IOException {
-                return ServletInputStreamWrapper.toJakartaServletInputStream(from.getInputStream());
-            }
-
-            @Override
-            public String getParameter(String name) {
-                return from.getParameter(name);
-            }
-
-            @Override
-            public Enumeration<String> getParameterNames() {
-                return from.getParameterNames();
-            }
-
-            @Override
-            public String[] getParameterValues(String name) {
-                return from.getParameterValues(name);
-            }
-
-            @Override
-            public Map<String, String[]> getParameterMap() {
-                return from.getParameterMap();
-            }
-
-            @Override
-            public String getProtocol() {
-                return from.getProtocol();
-            }
-
-            @Override
-            public String getScheme() {
-                return from.getScheme();
-            }
-
-            @Override
-            public String getServerName() {
-                return from.getServerName();
-            }
-
-            @Override
-            public int getServerPort() {
-                return from.getServerPort();
-            }
-
-            @Override
-            public BufferedReader getReader() throws IOException {
-                return from.getReader();
-            }
-
-            @Override
-            public String getRemoteAddr() {
-                return from.getRemoteAddr();
-            }
-
-            @Override
-            public String getRemoteHost() {
-                return from.getRemoteHost();
-            }
-
-            @Override
-            public void setAttribute(String name, Object o) {
-                from.setAttribute(name, o);
-            }
-
-            @Override
-            public void removeAttribute(String name) {
-                from.removeAttribute(name);
-            }
-
-            @Override
-            public Locale getLocale() {
-                return from.getLocale();
-            }
-
-            @Override
-            public Enumeration<Locale> getLocales() {
-                return from.getLocales();
-            }
-
-            @Override
-            public boolean isSecure() {
-                return from.isSecure();
-            }
-
-            @Override
-            public jakarta.servlet.RequestDispatcher getRequestDispatcher(String path) {
-                return RequestDispatcherWrapper.toJakartaRequestDispatcher(from.getRequestDispatcher(path));
-            }
-
-            @Override
-            public String getRealPath(String path) {
-                return from.getRealPath(path);
-            }
-
-            @Override
-            public int getRemotePort() {
-                return from.getRemotePort();
-            }
-
-            @Override
-            public String getLocalName() {
-                return from.getLocalName();
-            }
-
-            @Override
-            public String getLocalAddr() {
-                return from.getLocalAddr();
-            }
-
-            @Override
-            public int getLocalPort() {
-                return from.getLocalPort();
-            }
-
-            @Override
-            public jakarta.servlet.ServletContext getServletContext() {
-                return ServletContextWrapper.toJakartaServletContext(from.getServletContext());
-            }
-
-            @Override
-            public jakarta.servlet.AsyncContext startAsync() {
-                return AsyncContextWrapper.toJakartaAsyncContext(from.startAsync());
-            }
-
-            @Override
-            public jakarta.servlet.AsyncContext startAsync(
-                    jakarta.servlet.ServletRequest servletRequest, jakarta.servlet.ServletResponse servletResponse) {
-                return AsyncContextWrapper.toJakartaAsyncContext(from.startAsync(
-                        fromJakartaServletRequest(servletRequest),
-                        ServletResponseWrapper.fromJakartaServletResponse(servletResponse)));
-            }
-
-            @Override
-            public boolean isAsyncStarted() {
-                return from.isAsyncStarted();
-            }
-
-            @Override
-            public boolean isAsyncSupported() {
-                return from.isAsyncSupported();
-            }
-
-            @Override
-            public jakarta.servlet.AsyncContext getAsyncContext() {
-                return AsyncContextWrapper.toJakartaAsyncContext(from.getAsyncContext());
-            }
-
-            @Override
-            public jakarta.servlet.DispatcherType getDispatcherType() {
-                return DispatcherTypeWrapper.toJakartaDispatcherType(from.getDispatcherType());
-            }
-        };
+        if (from instanceof JavaxServletRequestWrapper javax) {
+            return javax.toJakartaServletRequest();
+        }
+        return new JakartaServletRequestWrapperImpl(from);
     }
 
     public static ServletRequest fromJakartaServletRequest(jakarta.servlet.ServletRequest from) {
-        Objects.requireNonNull(from);
-        return new ServletRequest() {
-            @Override
-            public Object getAttribute(String name) {
-                return from.getAttribute(name);
-            }
+        if (from instanceof JakartaServletRequestWrapper jakarta) {
+            return jakarta.toJavaxServletRequest();
+        }
+        return new JavaxServletRequestWrapperImpl(from);
+    }
 
-            @Override
-            public Enumeration<String> getAttributeNames() {
-                return from.getAttributeNames();
-            }
+    public interface JakartaServletRequestWrapper {
+        ServletRequest toJavaxServletRequest();
+    }
 
-            @Override
-            public String getCharacterEncoding() {
-                return from.getCharacterEncoding();
-            }
+    private static class JakartaServletRequestWrapperImpl
+            implements jakarta.servlet.ServletRequest, JakartaServletRequestWrapper {
+        private final ServletRequest from;
 
-            @Override
-            public void setCharacterEncoding(String env) throws UnsupportedEncodingException {
-                from.setCharacterEncoding(env);
-            }
+        public JakartaServletRequestWrapperImpl(ServletRequest from) {
+            this.from = Objects.requireNonNull(from);
+        }
 
-            @Override
-            public int getContentLength() {
-                return from.getContentLength();
-            }
+        @Override
+        public Object getAttribute(String name) {
+            return from.getAttribute(name);
+        }
 
-            @Override
-            public long getContentLengthLong() {
-                return from.getContentLengthLong();
-            }
+        @Override
+        public Enumeration<String> getAttributeNames() {
+            return from.getAttributeNames();
+        }
 
-            @Override
-            public String getContentType() {
-                return from.getContentType();
-            }
+        @Override
+        public String getCharacterEncoding() {
+            return from.getCharacterEncoding();
+        }
 
-            @Override
-            public ServletInputStream getInputStream() throws IOException {
-                return ServletInputStreamWrapper.fromJakartaServletInputStream(from.getInputStream());
-            }
+        @Override
+        public void setCharacterEncoding(String env) throws UnsupportedEncodingException {
+            from.setCharacterEncoding(env);
+        }
 
-            @Override
-            public String getParameter(String name) {
-                return from.getParameter(name);
-            }
+        @Override
+        public int getContentLength() {
+            return from.getContentLength();
+        }
 
-            @Override
-            public Enumeration<String> getParameterNames() {
-                return from.getParameterNames();
-            }
+        @Override
+        public long getContentLengthLong() {
+            return from.getContentLengthLong();
+        }
 
-            @Override
-            public String[] getParameterValues(String name) {
-                return from.getParameterValues(name);
-            }
+        @Override
+        public String getContentType() {
+            return from.getContentType();
+        }
 
-            @Override
-            public Map<String, String[]> getParameterMap() {
-                return from.getParameterMap();
-            }
+        @Override
+        public jakarta.servlet.ServletInputStream getInputStream() throws IOException {
+            return ServletInputStreamWrapper.toJakartaServletInputStream(from.getInputStream());
+        }
 
-            @Override
-            public String getProtocol() {
-                return from.getProtocol();
-            }
+        @Override
+        public String getParameter(String name) {
+            return from.getParameter(name);
+        }
 
-            @Override
-            public String getScheme() {
-                return from.getScheme();
-            }
+        @Override
+        public Enumeration<String> getParameterNames() {
+            return from.getParameterNames();
+        }
 
-            @Override
-            public String getServerName() {
-                return from.getServerName();
-            }
+        @Override
+        public String[] getParameterValues(String name) {
+            return from.getParameterValues(name);
+        }
 
-            @Override
-            public int getServerPort() {
-                return from.getServerPort();
-            }
+        @Override
+        public Map<String, String[]> getParameterMap() {
+            return from.getParameterMap();
+        }
 
-            @Override
-            public BufferedReader getReader() throws IOException {
-                return from.getReader();
-            }
+        @Override
+        public String getProtocol() {
+            return from.getProtocol();
+        }
 
-            @Override
-            public String getRemoteAddr() {
-                return from.getRemoteAddr();
-            }
+        @Override
+        public String getScheme() {
+            return from.getScheme();
+        }
 
-            @Override
-            public String getRemoteHost() {
-                return from.getRemoteHost();
-            }
+        @Override
+        public String getServerName() {
+            return from.getServerName();
+        }
 
-            @Override
-            public void setAttribute(String name, Object o) {
-                from.setAttribute(name, o);
-            }
+        @Override
+        public int getServerPort() {
+            return from.getServerPort();
+        }
 
-            @Override
-            public void removeAttribute(String name) {
-                from.removeAttribute(name);
-            }
+        @Override
+        public BufferedReader getReader() throws IOException {
+            return from.getReader();
+        }
 
-            @Override
-            public Locale getLocale() {
-                return from.getLocale();
-            }
+        @Override
+        public String getRemoteAddr() {
+            return from.getRemoteAddr();
+        }
 
-            @Override
-            public Enumeration<Locale> getLocales() {
-                return from.getLocales();
-            }
+        @Override
+        public String getRemoteHost() {
+            return from.getRemoteHost();
+        }
 
-            @Override
-            public boolean isSecure() {
-                return from.isSecure();
-            }
+        @Override
+        public void setAttribute(String name, Object o) {
+            from.setAttribute(name, o);
+        }
 
-            @Override
-            public RequestDispatcher getRequestDispatcher(String path) {
-                return RequestDispatcherWrapper.fromJakartaRequestDispatcher(from.getRequestDispatcher(path));
-            }
+        @Override
+        public void removeAttribute(String name) {
+            from.removeAttribute(name);
+        }
 
-            @Override
-            public String getRealPath(String path) {
-                return from.getRealPath(path);
-            }
+        @Override
+        public Locale getLocale() {
+            return from.getLocale();
+        }
 
-            @Override
-            public int getRemotePort() {
-                return from.getRemotePort();
-            }
+        @Override
+        public Enumeration<Locale> getLocales() {
+            return from.getLocales();
+        }
 
-            @Override
-            public String getLocalName() {
-                return from.getLocalName();
-            }
+        @Override
+        public boolean isSecure() {
+            return from.isSecure();
+        }
 
-            @Override
-            public String getLocalAddr() {
-                return from.getLocalAddr();
-            }
+        @Override
+        public jakarta.servlet.RequestDispatcher getRequestDispatcher(String path) {
+            return RequestDispatcherWrapper.toJakartaRequestDispatcher(from.getRequestDispatcher(path));
+        }
 
-            @Override
-            public int getLocalPort() {
-                return from.getLocalPort();
-            }
+        @Override
+        public String getRealPath(String path) {
+            return from.getRealPath(path);
+        }
 
-            @Override
-            public ServletContext getServletContext() {
-                return ServletContextWrapper.fromJakartServletContext(from.getServletContext());
-            }
+        @Override
+        public int getRemotePort() {
+            return from.getRemotePort();
+        }
 
-            @Override
-            public AsyncContext startAsync() {
-                return AsyncContextWrapper.fromJakartaAsyncContext(from.startAsync());
-            }
+        @Override
+        public String getLocalName() {
+            return from.getLocalName();
+        }
 
-            @Override
-            public AsyncContext startAsync(ServletRequest servletRequest, ServletResponse servletResponse) {
-                return AsyncContextWrapper.fromJakartaAsyncContext(from.startAsync(
-                        toJakartaServletRequest(servletRequest),
-                        ServletResponseWrapper.toJakartaServletResponse(servletResponse)));
-            }
+        @Override
+        public String getLocalAddr() {
+            return from.getLocalAddr();
+        }
 
-            @Override
-            public boolean isAsyncStarted() {
-                return from.isAsyncStarted();
-            }
+        @Override
+        public int getLocalPort() {
+            return from.getLocalPort();
+        }
 
-            @Override
-            public boolean isAsyncSupported() {
-                return from.isAsyncSupported();
-            }
+        @Override
+        public jakarta.servlet.ServletContext getServletContext() {
+            return ServletContextWrapper.toJakartaServletContext(from.getServletContext());
+        }
 
-            @Override
-            public AsyncContext getAsyncContext() {
-                return AsyncContextWrapper.fromJakartaAsyncContext(from.getAsyncContext());
-            }
+        @Override
+        public jakarta.servlet.AsyncContext startAsync() {
+            return AsyncContextWrapper.toJakartaAsyncContext(from.startAsync());
+        }
 
-            @Override
-            public DispatcherType getDispatcherType() {
-                return DispatcherTypeWrapper.fromJakartaDispatcherType(from.getDispatcherType());
-            }
-        };
+        @Override
+        public jakarta.servlet.AsyncContext startAsync(
+                jakarta.servlet.ServletRequest servletRequest, jakarta.servlet.ServletResponse servletResponse) {
+            return AsyncContextWrapper.toJakartaAsyncContext(from.startAsync(
+                    fromJakartaServletRequest(servletRequest),
+                    ServletResponseWrapper.fromJakartaServletResponse(servletResponse)));
+        }
+
+        @Override
+        public boolean isAsyncStarted() {
+            return from.isAsyncStarted();
+        }
+
+        @Override
+        public boolean isAsyncSupported() {
+            return from.isAsyncSupported();
+        }
+
+        @Override
+        public jakarta.servlet.AsyncContext getAsyncContext() {
+            return AsyncContextWrapper.toJakartaAsyncContext(from.getAsyncContext());
+        }
+
+        @Override
+        public jakarta.servlet.DispatcherType getDispatcherType() {
+            return DispatcherTypeWrapper.toJakartaDispatcherType(from.getDispatcherType());
+        }
+
+        @Override
+        public ServletRequest toJavaxServletRequest() {
+            return from;
+        }
+    }
+
+    public interface JavaxServletRequestWrapper {
+        jakarta.servlet.ServletRequest toJakartaServletRequest();
+    }
+
+    private static class JavaxServletRequestWrapperImpl implements ServletRequest, JavaxServletRequestWrapper {
+        private final jakarta.servlet.ServletRequest from;
+
+        public JavaxServletRequestWrapperImpl(jakarta.servlet.ServletRequest from) {
+            this.from = Objects.requireNonNull(from);
+        }
+
+        @Override
+        public Object getAttribute(String name) {
+            return from.getAttribute(name);
+        }
+
+        @Override
+        public Enumeration<String> getAttributeNames() {
+            return from.getAttributeNames();
+        }
+
+        @Override
+        public String getCharacterEncoding() {
+            return from.getCharacterEncoding();
+        }
+
+        @Override
+        public void setCharacterEncoding(String env) throws UnsupportedEncodingException {
+            from.setCharacterEncoding(env);
+        }
+
+        @Override
+        public int getContentLength() {
+            return from.getContentLength();
+        }
+
+        @Override
+        public long getContentLengthLong() {
+            return from.getContentLengthLong();
+        }
+
+        @Override
+        public String getContentType() {
+            return from.getContentType();
+        }
+
+        @Override
+        public ServletInputStream getInputStream() throws IOException {
+            return ServletInputStreamWrapper.fromJakartaServletInputStream(from.getInputStream());
+        }
+
+        @Override
+        public String getParameter(String name) {
+            return from.getParameter(name);
+        }
+
+        @Override
+        public Enumeration<String> getParameterNames() {
+            return from.getParameterNames();
+        }
+
+        @Override
+        public String[] getParameterValues(String name) {
+            return from.getParameterValues(name);
+        }
+
+        @Override
+        public Map<String, String[]> getParameterMap() {
+            return from.getParameterMap();
+        }
+
+        @Override
+        public String getProtocol() {
+            return from.getProtocol();
+        }
+
+        @Override
+        public String getScheme() {
+            return from.getScheme();
+        }
+
+        @Override
+        public String getServerName() {
+            return from.getServerName();
+        }
+
+        @Override
+        public int getServerPort() {
+            return from.getServerPort();
+        }
+
+        @Override
+        public BufferedReader getReader() throws IOException {
+            return from.getReader();
+        }
+
+        @Override
+        public String getRemoteAddr() {
+            return from.getRemoteAddr();
+        }
+
+        @Override
+        public String getRemoteHost() {
+            return from.getRemoteHost();
+        }
+
+        @Override
+        public void setAttribute(String name, Object o) {
+            from.setAttribute(name, o);
+        }
+
+        @Override
+        public void removeAttribute(String name) {
+            from.removeAttribute(name);
+        }
+
+        @Override
+        public Locale getLocale() {
+            return from.getLocale();
+        }
+
+        @Override
+        public Enumeration<Locale> getLocales() {
+            return from.getLocales();
+        }
+
+        @Override
+        public boolean isSecure() {
+            return from.isSecure();
+        }
+
+        @Override
+        public RequestDispatcher getRequestDispatcher(String path) {
+            return RequestDispatcherWrapper.fromJakartaRequestDispatcher(from.getRequestDispatcher(path));
+        }
+
+        @Override
+        public String getRealPath(String path) {
+            return from.getRealPath(path);
+        }
+
+        @Override
+        public int getRemotePort() {
+            return from.getRemotePort();
+        }
+
+        @Override
+        public String getLocalName() {
+            return from.getLocalName();
+        }
+
+        @Override
+        public String getLocalAddr() {
+            return from.getLocalAddr();
+        }
+
+        @Override
+        public int getLocalPort() {
+            return from.getLocalPort();
+        }
+
+        @Override
+        public ServletContext getServletContext() {
+            return ServletContextWrapper.fromJakartServletContext(from.getServletContext());
+        }
+
+        @Override
+        public AsyncContext startAsync() {
+            return AsyncContextWrapper.fromJakartaAsyncContext(from.startAsync());
+        }
+
+        @Override
+        public AsyncContext startAsync(ServletRequest servletRequest, ServletResponse servletResponse) {
+            return AsyncContextWrapper.fromJakartaAsyncContext(from.startAsync(
+                    ServletRequestWrapper.toJakartaServletRequest(servletRequest),
+                    ServletResponseWrapper.toJakartaServletResponse(servletResponse)));
+        }
+
+        @Override
+        public boolean isAsyncStarted() {
+            return from.isAsyncStarted();
+        }
+
+        @Override
+        public boolean isAsyncSupported() {
+            return from.isAsyncSupported();
+        }
+
+        @Override
+        public AsyncContext getAsyncContext() {
+            return AsyncContextWrapper.fromJakartaAsyncContext(from.getAsyncContext());
+        }
+
+        @Override
+        public DispatcherType getDispatcherType() {
+            return DispatcherTypeWrapper.fromJakartaDispatcherType(from.getDispatcherType());
+        }
+
+        @Override
+        public jakarta.servlet.ServletRequest toJakartaServletRequest() {
+            return from;
+        }
     }
 }

--- a/src/main/java/io/jenkins/servlet/ServletResponseWrapper.java
+++ b/src/main/java/io/jenkins/servlet/ServletResponseWrapper.java
@@ -9,172 +9,211 @@ import javax.servlet.ServletResponse;
 
 public class ServletResponseWrapper {
     public static jakarta.servlet.ServletResponse toJakartaServletResponse(ServletResponse from) {
-        Objects.requireNonNull(from);
-        return new jakarta.servlet.ServletResponse() {
-            @Override
-            public String getCharacterEncoding() {
-                return from.getCharacterEncoding();
-            }
-
-            @Override
-            public String getContentType() {
-                return from.getContentType();
-            }
-
-            @Override
-            public jakarta.servlet.ServletOutputStream getOutputStream() throws IOException {
-                return ServletOutputStreamWrapper.toJakartaServletOutputStream(from.getOutputStream());
-            }
-
-            @Override
-            public PrintWriter getWriter() throws IOException {
-                return from.getWriter();
-            }
-
-            @Override
-            public void setCharacterEncoding(String charset) {
-                from.setCharacterEncoding(charset);
-            }
-
-            @Override
-            public void setContentLength(int len) {
-                from.setContentLength(len);
-            }
-
-            @Override
-            public void setContentLengthLong(long len) {
-                from.setContentLengthLong(len);
-            }
-
-            @Override
-            public void setContentType(String type) {
-                from.setContentType(type);
-            }
-
-            @Override
-            public void setBufferSize(int size) {
-                from.setBufferSize(size);
-            }
-
-            @Override
-            public int getBufferSize() {
-                return from.getBufferSize();
-            }
-
-            @Override
-            public void flushBuffer() throws IOException {
-                from.flushBuffer();
-            }
-
-            @Override
-            public void resetBuffer() {
-                from.resetBuffer();
-            }
-
-            @Override
-            public boolean isCommitted() {
-                return from.isCommitted();
-            }
-
-            @Override
-            public void reset() {
-                from.reset();
-            }
-
-            @Override
-            public void setLocale(Locale loc) {
-                from.setLocale(loc);
-            }
-
-            @Override
-            public Locale getLocale() {
-                return from.getLocale();
-            }
-        };
+        if (from instanceof JavaxServletResponseWrapper javax) {
+            return javax.toJakartaServletResponse();
+        }
+        return new JakartaServletResponseWrapperImpl(from);
     }
 
     public static ServletResponse fromJakartaServletResponse(jakarta.servlet.ServletResponse from) {
-        Objects.requireNonNull(from);
-        return new ServletResponse() {
-            @Override
-            public String getCharacterEncoding() {
-                return from.getCharacterEncoding();
-            }
+        if (from instanceof JakartaServletResponseWrapper jakarta) {
+            return jakarta.toJavaxServletResponse();
+        }
+        return new JavaxServletResponseWrapperImpl(from);
+    }
 
-            @Override
-            public String getContentType() {
-                return from.getContentType();
-            }
+    public interface JakartaServletResponseWrapper {
+        ServletResponse toJavaxServletResponse();
+    }
 
-            @Override
-            public ServletOutputStream getOutputStream() throws IOException {
-                return ServletOutputStreamWrapper.fromJakartaServletOutputStream(from.getOutputStream());
-            }
+    private static class JakartaServletResponseWrapperImpl
+            implements jakarta.servlet.ServletResponse, JakartaServletResponseWrapper {
+        private final ServletResponse from;
 
-            @Override
-            public PrintWriter getWriter() throws IOException {
-                return from.getWriter();
-            }
+        public JakartaServletResponseWrapperImpl(ServletResponse from) {
+            this.from = Objects.requireNonNull(from);
+        }
 
-            @Override
-            public void setCharacterEncoding(String charset) {
-                from.setCharacterEncoding(charset);
-            }
+        @Override
+        public String getCharacterEncoding() {
+            return from.getCharacterEncoding();
+        }
 
-            @Override
-            public void setContentLength(int len) {
-                from.setContentLength(len);
-            }
+        @Override
+        public String getContentType() {
+            return from.getContentType();
+        }
 
-            @Override
-            public void setContentLengthLong(long len) {
-                from.setContentLengthLong(len);
-            }
+        @Override
+        public jakarta.servlet.ServletOutputStream getOutputStream() throws IOException {
+            return ServletOutputStreamWrapper.toJakartaServletOutputStream(from.getOutputStream());
+        }
 
-            @Override
-            public void setContentType(String type) {
-                from.setContentType(type);
-            }
+        @Override
+        public PrintWriter getWriter() throws IOException {
+            return from.getWriter();
+        }
 
-            @Override
-            public void setBufferSize(int size) {
-                from.setBufferSize(size);
-            }
+        @Override
+        public void setCharacterEncoding(String charset) {
+            from.setCharacterEncoding(charset);
+        }
 
-            @Override
-            public int getBufferSize() {
-                return from.getBufferSize();
-            }
+        @Override
+        public void setContentLength(int len) {
+            from.setContentLength(len);
+        }
 
-            @Override
-            public void flushBuffer() throws IOException {
-                from.flushBuffer();
-            }
+        @Override
+        public void setContentLengthLong(long len) {
+            from.setContentLengthLong(len);
+        }
 
-            @Override
-            public void resetBuffer() {
-                from.resetBuffer();
-            }
+        @Override
+        public void setContentType(String type) {
+            from.setContentType(type);
+        }
 
-            @Override
-            public boolean isCommitted() {
-                return from.isCommitted();
-            }
+        @Override
+        public void setBufferSize(int size) {
+            from.setBufferSize(size);
+        }
 
-            @Override
-            public void reset() {
-                from.reset();
-            }
+        @Override
+        public int getBufferSize() {
+            return from.getBufferSize();
+        }
 
-            @Override
-            public void setLocale(Locale loc) {
-                from.setLocale(loc);
-            }
+        @Override
+        public void flushBuffer() throws IOException {
+            from.flushBuffer();
+        }
 
-            @Override
-            public Locale getLocale() {
-                return from.getLocale();
-            }
-        };
+        @Override
+        public void resetBuffer() {
+            from.resetBuffer();
+        }
+
+        @Override
+        public boolean isCommitted() {
+            return from.isCommitted();
+        }
+
+        @Override
+        public void reset() {
+            from.reset();
+        }
+
+        @Override
+        public void setLocale(Locale loc) {
+            from.setLocale(loc);
+        }
+
+        @Override
+        public Locale getLocale() {
+            return from.getLocale();
+        }
+
+        @Override
+        public ServletResponse toJavaxServletResponse() {
+            return from;
+        }
+    }
+
+    public interface JavaxServletResponseWrapper {
+        jakarta.servlet.ServletResponse toJakartaServletResponse();
+    }
+
+    private static class JavaxServletResponseWrapperImpl implements ServletResponse, JavaxServletResponseWrapper {
+        private final jakarta.servlet.ServletResponse from;
+
+        public JavaxServletResponseWrapperImpl(jakarta.servlet.ServletResponse from) {
+            this.from = Objects.requireNonNull(from);
+        }
+
+        @Override
+        public String getCharacterEncoding() {
+            return from.getCharacterEncoding();
+        }
+
+        @Override
+        public String getContentType() {
+            return from.getContentType();
+        }
+
+        @Override
+        public ServletOutputStream getOutputStream() throws IOException {
+            return ServletOutputStreamWrapper.fromJakartaServletOutputStream(from.getOutputStream());
+        }
+
+        @Override
+        public PrintWriter getWriter() throws IOException {
+            return from.getWriter();
+        }
+
+        @Override
+        public void setCharacterEncoding(String charset) {
+            from.setCharacterEncoding(charset);
+        }
+
+        @Override
+        public void setContentLength(int len) {
+            from.setContentLength(len);
+        }
+
+        @Override
+        public void setContentLengthLong(long len) {
+            from.setContentLengthLong(len);
+        }
+
+        @Override
+        public void setContentType(String type) {
+            from.setContentType(type);
+        }
+
+        @Override
+        public void setBufferSize(int size) {
+            from.setBufferSize(size);
+        }
+
+        @Override
+        public int getBufferSize() {
+            return from.getBufferSize();
+        }
+
+        @Override
+        public void flushBuffer() throws IOException {
+            from.flushBuffer();
+        }
+
+        @Override
+        public void resetBuffer() {
+            from.resetBuffer();
+        }
+
+        @Override
+        public boolean isCommitted() {
+            return from.isCommitted();
+        }
+
+        @Override
+        public void reset() {
+            from.reset();
+        }
+
+        @Override
+        public void setLocale(Locale loc) {
+            from.setLocale(loc);
+        }
+
+        @Override
+        public Locale getLocale() {
+            return from.getLocale();
+        }
+
+        @Override
+        public jakarta.servlet.ServletResponse toJakartaServletResponse() {
+            return from;
+        }
     }
 }

--- a/src/main/java/io/jenkins/servlet/http/HttpServletRequestWrapper.java
+++ b/src/main/java/io/jenkins/servlet/http/HttpServletRequestWrapper.java
@@ -39,805 +39,842 @@ import javax.servlet.http.PushBuilder;
 public class HttpServletRequestWrapper {
 
     public static jakarta.servlet.http.HttpServletRequest toJakartaHttpServletRequest(HttpServletRequest from) {
-        Objects.requireNonNull(from);
-        return new jakarta.servlet.http.HttpServletRequest() {
-            @Override
-            public Object getAttribute(String name) {
-                return from.getAttribute(name);
-            }
-
-            @Override
-            public Enumeration<String> getAttributeNames() {
-                return from.getAttributeNames();
-            }
-
-            @Override
-            public String getCharacterEncoding() {
-                return from.getCharacterEncoding();
-            }
-
-            @Override
-            public void setCharacterEncoding(String env) throws UnsupportedEncodingException {
-                from.setCharacterEncoding(env);
-            }
-
-            @Override
-            public int getContentLength() {
-                return from.getContentLength();
-            }
-
-            @Override
-            public long getContentLengthLong() {
-                return from.getContentLengthLong();
-            }
-
-            @Override
-            public String getContentType() {
-                return from.getContentType();
-            }
-
-            @Override
-            public jakarta.servlet.ServletInputStream getInputStream() throws IOException {
-                return ServletInputStreamWrapper.toJakartaServletInputStream(from.getInputStream());
-            }
-
-            @Override
-            public String getParameter(String name) {
-                return from.getParameter(name);
-            }
-
-            @Override
-            public Enumeration<String> getParameterNames() {
-                return from.getParameterNames();
-            }
-
-            @Override
-            public String[] getParameterValues(String name) {
-                return from.getParameterValues(name);
-            }
-
-            @Override
-            public Map<String, String[]> getParameterMap() {
-                return from.getParameterMap();
-            }
-
-            @Override
-            public String getProtocol() {
-                return from.getProtocol();
-            }
-
-            @Override
-            public String getScheme() {
-                return from.getScheme();
-            }
-
-            @Override
-            public String getServerName() {
-                return from.getServerName();
-            }
-
-            @Override
-            public int getServerPort() {
-                return from.getServerPort();
-            }
-
-            @Override
-            public BufferedReader getReader() throws IOException {
-                return from.getReader();
-            }
-
-            @Override
-            public String getRemoteAddr() {
-                return from.getRemoteAddr();
-            }
-
-            @Override
-            public String getRemoteHost() {
-                return from.getRemoteHost();
-            }
-
-            @Override
-            public void setAttribute(String name, Object o) {
-                from.setAttribute(name, o);
-            }
-
-            @Override
-            public void removeAttribute(String name) {
-                from.removeAttribute(name);
-            }
-
-            @Override
-            public Locale getLocale() {
-                return from.getLocale();
-            }
-
-            @Override
-            public Enumeration<Locale> getLocales() {
-                return from.getLocales();
-            }
-
-            @Override
-            public boolean isSecure() {
-                return from.isSecure();
-            }
-
-            @Override
-            public jakarta.servlet.RequestDispatcher getRequestDispatcher(String path) {
-                return RequestDispatcherWrapper.toJakartaRequestDispatcher(from.getRequestDispatcher(path));
-            }
-
-            @Override
-            public String getRealPath(String path) {
-                return from.getRealPath(path);
-            }
-
-            @Override
-            public int getRemotePort() {
-                return from.getRemotePort();
-            }
-
-            @Override
-            public String getLocalName() {
-                return from.getLocalName();
-            }
-
-            @Override
-            public String getLocalAddr() {
-                return from.getLocalAddr();
-            }
-
-            @Override
-            public int getLocalPort() {
-                return from.getLocalPort();
-            }
-
-            @Override
-            public jakarta.servlet.ServletContext getServletContext() {
-                return ServletContextWrapper.toJakartaServletContext(from.getServletContext());
-            }
-
-            @Override
-            public jakarta.servlet.AsyncContext startAsync() {
-                return AsyncContextWrapper.toJakartaAsyncContext(from.startAsync());
-            }
-
-            @Override
-            public jakarta.servlet.AsyncContext startAsync(
-                    jakarta.servlet.ServletRequest servletRequest, jakarta.servlet.ServletResponse servletResponse) {
-                return AsyncContextWrapper.toJakartaAsyncContext(from.startAsync(
-                        ServletRequestWrapper.fromJakartaServletRequest(servletRequest),
-                        ServletResponseWrapper.fromJakartaServletResponse(servletResponse)));
-            }
-
-            @Override
-            public boolean isAsyncStarted() {
-                return from.isAsyncStarted();
-            }
-
-            @Override
-            public boolean isAsyncSupported() {
-                return from.isAsyncSupported();
-            }
-
-            @Override
-            public jakarta.servlet.AsyncContext getAsyncContext() {
-                return AsyncContextWrapper.toJakartaAsyncContext(from.getAsyncContext());
-            }
-
-            @Override
-            public jakarta.servlet.DispatcherType getDispatcherType() {
-                return DispatcherTypeWrapper.toJakartaDispatcherType(from.getDispatcherType());
-            }
-
-            @Override
-            public String getAuthType() {
-                return from.getAuthType();
-            }
-
-            @Override
-            public jakarta.servlet.http.Cookie[] getCookies() {
-                return Stream.of(from.getCookies())
-                        .map(CookieWrapper::toJakartaServletHttpCookie)
-                        .toArray(jakarta.servlet.http.Cookie[]::new);
-            }
-
-            @Override
-            public long getDateHeader(String name) {
-                return from.getDateHeader(name);
-            }
-
-            @Override
-            public String getHeader(String name) {
-                return from.getHeader(name);
-            }
-
-            @Override
-            public Enumeration<String> getHeaders(String name) {
-                return from.getHeaders(name);
-            }
-
-            @Override
-            public Enumeration<String> getHeaderNames() {
-                return from.getHeaderNames();
-            }
-
-            @Override
-            public int getIntHeader(String name) {
-                return from.getIntHeader(name);
-            }
-
-            @Override
-            public jakarta.servlet.http.HttpServletMapping getHttpServletMapping() {
-                return HttpServletMappingWrapper.toJakartaHttpServletMapping(from.getHttpServletMapping());
-            }
-
-            @Override
-            public String getMethod() {
-                return from.getMethod();
-            }
-
-            @Override
-            public String getPathInfo() {
-                return from.getPathInfo();
-            }
-
-            @Override
-            public String getPathTranslated() {
-                return from.getPathTranslated();
-            }
-
-            @Override
-            public jakarta.servlet.http.PushBuilder newPushBuilder() {
-                // TODO implement this
-                throw new UnsupportedOperationException();
-            }
-
-            @Override
-            public String getContextPath() {
-                return from.getContextPath();
-            }
-
-            @Override
-            public String getQueryString() {
-                return from.getQueryString();
-            }
-
-            @Override
-            public String getRemoteUser() {
-                return from.getRemoteUser();
-            }
-
-            @Override
-            public boolean isUserInRole(String role) {
-                return from.isUserInRole(role);
-            }
-
-            @Override
-            public Principal getUserPrincipal() {
-                return from.getUserPrincipal();
-            }
-
-            @Override
-            public String getRequestedSessionId() {
-                return from.getRequestedSessionId();
-            }
-
-            @Override
-            public String getRequestURI() {
-                return from.getRequestURI();
-            }
-
-            @Override
-            public StringBuffer getRequestURL() {
-                return from.getRequestURL();
-            }
-
-            @Override
-            public String getServletPath() {
-                return from.getServletPath();
-            }
-
-            @Override
-            public jakarta.servlet.http.HttpSession getSession(boolean create) {
-                HttpSession session = from.getSession(create);
-                return session != null ? HttpSessionWrapper.toJakartaHttpSession(session) : null;
-            }
-
-            @Override
-            public jakarta.servlet.http.HttpSession getSession() {
-                HttpSession session = from.getSession();
-                return session != null ? HttpSessionWrapper.toJakartaHttpSession(session) : null;
-            }
-
-            @Override
-            public String changeSessionId() {
-                return from.changeSessionId();
-            }
-
-            @Override
-            public boolean isRequestedSessionIdValid() {
-                return from.isRequestedSessionIdValid();
-            }
-
-            @Override
-            public boolean isRequestedSessionIdFromCookie() {
-                return from.isRequestedSessionIdFromCookie();
-            }
-
-            @Override
-            public boolean isRequestedSessionIdFromURL() {
-                return from.isRequestedSessionIdFromURL();
-            }
-
-            @Override
-            public boolean isRequestedSessionIdFromUrl() {
-                return from.isRequestedSessionIdFromUrl();
-            }
-
-            @Override
-            public boolean authenticate(jakarta.servlet.http.HttpServletResponse response)
-                    throws IOException, jakarta.servlet.ServletException {
-                try {
-                    return from.authenticate(HttpServletResponseWrapper.fromJakartaHttpServletResponse(response));
-                } catch (ServletException e) {
-                    throw ServletExceptionWrapper.toJakartaServletException(e);
-                }
-            }
-
-            @Override
-            public void login(String username, String password) throws jakarta.servlet.ServletException {
-                try {
-                    from.login(username, password);
-                } catch (ServletException e) {
-                    throw ServletExceptionWrapper.toJakartaServletException(e);
-                }
-            }
-
-            @Override
-            public void logout() throws jakarta.servlet.ServletException {
-                try {
-                    from.logout();
-                } catch (ServletException e) {
-                    throw ServletExceptionWrapper.toJakartaServletException(e);
-                }
-            }
-
-            @Override
-            public Collection<jakarta.servlet.http.Part> getParts()
-                    throws IOException, jakarta.servlet.ServletException {
-                try {
-                    return from.getParts().stream()
-                            .map(PartWrapper::toJakartaPart)
-                            .collect(Collectors.toList());
-                } catch (ServletException e) {
-                    throw ServletExceptionWrapper.toJakartaServletException(e);
-                }
-            }
-
-            @Override
-            public jakarta.servlet.http.Part getPart(String name) throws IOException, jakarta.servlet.ServletException {
-                try {
-                    return PartWrapper.toJakartaPart(from.getPart(name));
-                } catch (ServletException e) {
-                    throw ServletExceptionWrapper.toJakartaServletException(e);
-                }
-            }
-
-            @Override
-            public <T extends jakarta.servlet.http.HttpUpgradeHandler> T upgrade(Class<T> handlerClass) {
-                // TODO implement this
-                throw new UnsupportedOperationException();
-            }
-
-            @Override
-            public Map<String, String> getTrailerFields() {
-                return from.getTrailerFields();
-            }
-
-            @Override
-            public boolean isTrailerFieldsReady() {
-                return from.isTrailerFieldsReady();
-            }
-        };
+        if (from instanceof JavaxHttpServletRequestWrapper javax) {
+            return javax.toJakartaHttpServletRequest();
+        }
+        return new JakartaHttpServletRequestWrapperImpl(from);
     }
 
     public static HttpServletRequest fromJakartaHttpServletRequest(jakarta.servlet.http.HttpServletRequest from) {
-        Objects.requireNonNull(from);
-        return new HttpServletRequest() {
-            @Override
-            public Object getAttribute(String name) {
-                return from.getAttribute(name);
-            }
-
-            @Override
-            public Enumeration<String> getAttributeNames() {
-                return from.getAttributeNames();
-            }
-
-            @Override
-            public String getCharacterEncoding() {
-                return from.getCharacterEncoding();
-            }
-
-            @Override
-            public void setCharacterEncoding(String env) throws UnsupportedEncodingException {
-                from.setCharacterEncoding(env);
-            }
-
-            @Override
-            public int getContentLength() {
-                return from.getContentLength();
-            }
-
-            @Override
-            public long getContentLengthLong() {
-                return from.getContentLengthLong();
-            }
-
-            @Override
-            public String getContentType() {
-                return from.getContentType();
-            }
-
-            @Override
-            public ServletInputStream getInputStream() throws IOException {
-                return ServletInputStreamWrapper.fromJakartaServletInputStream(from.getInputStream());
-            }
-
-            @Override
-            public String getParameter(String name) {
-                return from.getParameter(name);
-            }
-
-            @Override
-            public Enumeration<String> getParameterNames() {
-                return from.getParameterNames();
-            }
-
-            @Override
-            public String[] getParameterValues(String name) {
-                return from.getParameterValues(name);
-            }
-
-            @Override
-            public Map<String, String[]> getParameterMap() {
-                return from.getParameterMap();
-            }
-
-            @Override
-            public String getProtocol() {
-                return from.getProtocol();
-            }
-
-            @Override
-            public String getScheme() {
-                return from.getScheme();
-            }
-
-            @Override
-            public String getServerName() {
-                return from.getServerName();
-            }
-
-            @Override
-            public int getServerPort() {
-                return from.getServerPort();
-            }
-
-            @Override
-            public BufferedReader getReader() throws IOException {
-                return from.getReader();
-            }
-
-            @Override
-            public String getRemoteAddr() {
-                return from.getRemoteAddr();
-            }
-
-            @Override
-            public String getRemoteHost() {
-                return from.getRemoteHost();
-            }
-
-            @Override
-            public void setAttribute(String name, Object o) {
-                from.setAttribute(name, o);
-            }
-
-            @Override
-            public void removeAttribute(String name) {
-                from.removeAttribute(name);
-            }
-
-            @Override
-            public Locale getLocale() {
-                return from.getLocale();
-            }
-
-            @Override
-            public Enumeration<Locale> getLocales() {
-                return from.getLocales();
-            }
-
-            @Override
-            public boolean isSecure() {
-                return from.isSecure();
-            }
-
-            @Override
-            public RequestDispatcher getRequestDispatcher(String path) {
-                return RequestDispatcherWrapper.fromJakartaRequestDispatcher(from.getRequestDispatcher(path));
-            }
-
-            @Override
-            public String getRealPath(String path) {
-                return from.getRealPath(path);
-            }
-
-            @Override
-            public int getRemotePort() {
-                return from.getRemotePort();
-            }
-
-            @Override
-            public String getLocalName() {
-                return from.getLocalName();
-            }
-
-            @Override
-            public String getLocalAddr() {
-                return from.getLocalAddr();
-            }
-
-            @Override
-            public int getLocalPort() {
-                return from.getLocalPort();
-            }
-
-            @Override
-            public ServletContext getServletContext() {
-                return ServletContextWrapper.fromJakartServletContext(from.getServletContext());
-            }
-
-            @Override
-            public AsyncContext startAsync() {
-                return AsyncContextWrapper.fromJakartaAsyncContext(from.startAsync());
-            }
-
-            @Override
-            public AsyncContext startAsync(ServletRequest servletRequest, ServletResponse servletResponse) {
-                return AsyncContextWrapper.fromJakartaAsyncContext(from.startAsync(
-                        ServletRequestWrapper.toJakartaServletRequest(servletRequest),
-                        io.jenkins.servlet.ServletResponseWrapper.toJakartaServletResponse(servletResponse)));
-            }
-
-            @Override
-            public boolean isAsyncStarted() {
-                return from.isAsyncStarted();
-            }
-
-            @Override
-            public boolean isAsyncSupported() {
-                return from.isAsyncSupported();
-            }
-
-            @Override
-            public AsyncContext getAsyncContext() {
-                return AsyncContextWrapper.fromJakartaAsyncContext(from.getAsyncContext());
-            }
-
-            @Override
-            public DispatcherType getDispatcherType() {
-                return DispatcherTypeWrapper.fromJakartaDispatcherType(from.getDispatcherType());
-            }
-
-            @Override
-            public String getAuthType() {
-                return from.getAuthType();
-            }
-
-            @Override
-            public Cookie[] getCookies() {
-                return Stream.of(from.getCookies())
-                        .map(CookieWrapper::fromJakartaServletHttpCookie)
-                        .toArray(Cookie[]::new);
-            }
-
-            @Override
-            public long getDateHeader(String name) {
-                return from.getDateHeader(name);
-            }
-
-            @Override
-            public String getHeader(String name) {
-                return from.getHeader(name);
-            }
-
-            @Override
-            public Enumeration<String> getHeaders(String name) {
-                return from.getHeaders(name);
-            }
-
-            @Override
-            public Enumeration<String> getHeaderNames() {
-                return from.getHeaderNames();
-            }
-
-            @Override
-            public int getIntHeader(String name) {
-                return from.getIntHeader(name);
-            }
-
-            @Override
-            public HttpServletMapping getHttpServletMapping() {
-                return HttpServletMappingWrapper.fromJakartaHttpServletMapping(from.getHttpServletMapping());
-            }
-
-            @Override
-            public String getMethod() {
-                return from.getMethod();
-            }
-
-            @Override
-            public String getPathInfo() {
-                return from.getPathInfo();
-            }
-
-            @Override
-            public String getPathTranslated() {
-                return from.getPathTranslated();
-            }
-
-            @Override
-            public PushBuilder newPushBuilder() {
-                // TODO implement this
-                throw new UnsupportedOperationException();
-            }
-
-            @Override
-            public String getContextPath() {
-                return from.getContextPath();
-            }
-
-            @Override
-            public String getQueryString() {
-                return from.getQueryString();
-            }
-
-            @Override
-            public String getRemoteUser() {
-                return from.getRemoteUser();
-            }
-
-            @Override
-            public boolean isUserInRole(String role) {
-                return from.isUserInRole(role);
-            }
-
-            @Override
-            public Principal getUserPrincipal() {
-                return from.getUserPrincipal();
-            }
-
-            @Override
-            public String getRequestedSessionId() {
-                return from.getRequestedSessionId();
-            }
-
-            @Override
-            public String getRequestURI() {
-                return from.getRequestURI();
-            }
-
-            @Override
-            public StringBuffer getRequestURL() {
-                return from.getRequestURL();
-            }
-
-            @Override
-            public String getServletPath() {
-                return from.getServletPath();
-            }
-
-            @Override
-            public HttpSession getSession(boolean create) {
-                jakarta.servlet.http.HttpSession session = from.getSession(create);
-                return session != null ? HttpSessionWrapper.fromJakartaHttpSession(session) : null;
-            }
-
-            @Override
-            public HttpSession getSession() {
-                jakarta.servlet.http.HttpSession session = from.getSession();
-                return session != null ? HttpSessionWrapper.fromJakartaHttpSession(session) : null;
-            }
-
-            @Override
-            public String changeSessionId() {
-                return from.changeSessionId();
-            }
-
-            @Override
-            public boolean isRequestedSessionIdValid() {
-                return from.isRequestedSessionIdValid();
-            }
-
-            @Override
-            public boolean isRequestedSessionIdFromCookie() {
-                return from.isRequestedSessionIdFromCookie();
-            }
-
-            @Override
-            public boolean isRequestedSessionIdFromURL() {
-                return from.isRequestedSessionIdFromURL();
-            }
-
-            @Override
-            public boolean isRequestedSessionIdFromUrl() {
-                return from.isRequestedSessionIdFromUrl();
-            }
-
-            @Override
-            public boolean authenticate(HttpServletResponse response) throws IOException, ServletException {
-                try {
-                    return from.authenticate(HttpServletResponseWrapper.toJakartaHttpServletResponse(response));
-                } catch (jakarta.servlet.ServletException e) {
-                    throw ServletExceptionWrapper.fromJakartaServletException(e);
-                }
-            }
-
-            @Override
-            public void login(String username, String password) throws ServletException {
-                try {
-                    from.login(username, password);
-                } catch (jakarta.servlet.ServletException e) {
-                    throw ServletExceptionWrapper.fromJakartaServletException(e);
-                }
-            }
-
-            @Override
-            public void logout() throws ServletException {
-                try {
-                    from.logout();
-                } catch (jakarta.servlet.ServletException e) {
-                    throw ServletExceptionWrapper.fromJakartaServletException(e);
-                }
-            }
-
-            @Override
-            public Collection<Part> getParts() throws IOException, ServletException {
-                try {
-                    return from.getParts().stream()
-                            .map(PartWrapper::fromJakartaPart)
-                            .collect(Collectors.toList());
-                } catch (jakarta.servlet.ServletException e) {
-                    throw ServletExceptionWrapper.fromJakartaServletException(e);
-                }
-            }
-
-            @Override
-            public Part getPart(String name) throws IOException, ServletException {
-                try {
-                    return PartWrapper.fromJakartaPart(from.getPart(name));
-                } catch (jakarta.servlet.ServletException e) {
-                    throw ServletExceptionWrapper.fromJakartaServletException(e);
-                }
-            }
-
-            @Override
-            public <T extends HttpUpgradeHandler> T upgrade(Class<T> handlerClass) {
-                // TODO implement this
-                throw new UnsupportedOperationException();
-            }
-
-            @Override
-            public Map<String, String> getTrailerFields() {
-                return from.getTrailerFields();
-            }
-
-            @Override
-            public boolean isTrailerFieldsReady() {
-                return from.isTrailerFieldsReady();
-            }
-        };
+        if (from instanceof JakartaHttpServletRequestWrapper jakarta) {
+            return jakarta.toJavaxHttpServletRequest();
+        }
+        return new JavaxHttpServletRequestWrapperImpl(from);
+    }
+
+    public interface JakartaHttpServletRequestWrapper {
+        HttpServletRequest toJavaxHttpServletRequest();
+    }
+
+    private static class JakartaHttpServletRequestWrapperImpl
+            implements jakarta.servlet.http.HttpServletRequest, ServletRequestWrapper.JakartaServletRequestWrapper {
+        private final HttpServletRequest from;
+
+        public JakartaHttpServletRequestWrapperImpl(HttpServletRequest from) {
+            this.from = Objects.requireNonNull(from);
+        }
+
+        @Override
+        public Object getAttribute(String name) {
+            return from.getAttribute(name);
+        }
+
+        @Override
+        public Enumeration<String> getAttributeNames() {
+            return from.getAttributeNames();
+        }
+
+        @Override
+        public String getCharacterEncoding() {
+            return from.getCharacterEncoding();
+        }
+
+        @Override
+        public void setCharacterEncoding(String env) throws UnsupportedEncodingException {
+            from.setCharacterEncoding(env);
+        }
+
+        @Override
+        public int getContentLength() {
+            return from.getContentLength();
+        }
+
+        @Override
+        public long getContentLengthLong() {
+            return from.getContentLengthLong();
+        }
+
+        @Override
+        public String getContentType() {
+            return from.getContentType();
+        }
+
+        @Override
+        public jakarta.servlet.ServletInputStream getInputStream() throws IOException {
+            return ServletInputStreamWrapper.toJakartaServletInputStream(from.getInputStream());
+        }
+
+        @Override
+        public String getParameter(String name) {
+            return from.getParameter(name);
+        }
+
+        @Override
+        public Enumeration<String> getParameterNames() {
+            return from.getParameterNames();
+        }
+
+        @Override
+        public String[] getParameterValues(String name) {
+            return from.getParameterValues(name);
+        }
+
+        @Override
+        public Map<String, String[]> getParameterMap() {
+            return from.getParameterMap();
+        }
+
+        @Override
+        public String getProtocol() {
+            return from.getProtocol();
+        }
+
+        @Override
+        public String getScheme() {
+            return from.getScheme();
+        }
+
+        @Override
+        public String getServerName() {
+            return from.getServerName();
+        }
+
+        @Override
+        public int getServerPort() {
+            return from.getServerPort();
+        }
+
+        @Override
+        public BufferedReader getReader() throws IOException {
+            return from.getReader();
+        }
+
+        @Override
+        public String getRemoteAddr() {
+            return from.getRemoteAddr();
+        }
+
+        @Override
+        public String getRemoteHost() {
+            return from.getRemoteHost();
+        }
+
+        @Override
+        public void setAttribute(String name, Object o) {
+            from.setAttribute(name, o);
+        }
+
+        @Override
+        public void removeAttribute(String name) {
+            from.removeAttribute(name);
+        }
+
+        @Override
+        public Locale getLocale() {
+            return from.getLocale();
+        }
+
+        @Override
+        public Enumeration<Locale> getLocales() {
+            return from.getLocales();
+        }
+
+        @Override
+        public boolean isSecure() {
+            return from.isSecure();
+        }
+
+        @Override
+        public jakarta.servlet.RequestDispatcher getRequestDispatcher(String path) {
+            return RequestDispatcherWrapper.toJakartaRequestDispatcher(from.getRequestDispatcher(path));
+        }
+
+        @Override
+        public String getRealPath(String path) {
+            return from.getRealPath(path);
+        }
+
+        @Override
+        public int getRemotePort() {
+            return from.getRemotePort();
+        }
+
+        @Override
+        public String getLocalName() {
+            return from.getLocalName();
+        }
+
+        @Override
+        public String getLocalAddr() {
+            return from.getLocalAddr();
+        }
+
+        @Override
+        public int getLocalPort() {
+            return from.getLocalPort();
+        }
+
+        @Override
+        public jakarta.servlet.ServletContext getServletContext() {
+            return ServletContextWrapper.toJakartaServletContext(from.getServletContext());
+        }
+
+        @Override
+        public jakarta.servlet.AsyncContext startAsync() {
+            return AsyncContextWrapper.toJakartaAsyncContext(from.startAsync());
+        }
+
+        @Override
+        public jakarta.servlet.AsyncContext startAsync(
+                jakarta.servlet.ServletRequest servletRequest, jakarta.servlet.ServletResponse servletResponse) {
+            return AsyncContextWrapper.toJakartaAsyncContext(from.startAsync(
+                    ServletRequestWrapper.fromJakartaServletRequest(servletRequest),
+                    ServletResponseWrapper.fromJakartaServletResponse(servletResponse)));
+        }
+
+        @Override
+        public boolean isAsyncStarted() {
+            return from.isAsyncStarted();
+        }
+
+        @Override
+        public boolean isAsyncSupported() {
+            return from.isAsyncSupported();
+        }
+
+        @Override
+        public jakarta.servlet.AsyncContext getAsyncContext() {
+            return AsyncContextWrapper.toJakartaAsyncContext(from.getAsyncContext());
+        }
+
+        @Override
+        public jakarta.servlet.DispatcherType getDispatcherType() {
+            return DispatcherTypeWrapper.toJakartaDispatcherType(from.getDispatcherType());
+        }
+
+        @Override
+        public String getAuthType() {
+            return from.getAuthType();
+        }
+
+        @Override
+        public jakarta.servlet.http.Cookie[] getCookies() {
+            return Stream.of(from.getCookies())
+                    .map(CookieWrapper::toJakartaServletHttpCookie)
+                    .toArray(jakarta.servlet.http.Cookie[]::new);
+        }
+
+        @Override
+        public long getDateHeader(String name) {
+            return from.getDateHeader(name);
+        }
+
+        @Override
+        public String getHeader(String name) {
+            return from.getHeader(name);
+        }
+
+        @Override
+        public Enumeration<String> getHeaders(String name) {
+            return from.getHeaders(name);
+        }
+
+        @Override
+        public Enumeration<String> getHeaderNames() {
+            return from.getHeaderNames();
+        }
+
+        @Override
+        public int getIntHeader(String name) {
+            return from.getIntHeader(name);
+        }
+
+        @Override
+        public jakarta.servlet.http.HttpServletMapping getHttpServletMapping() {
+            return HttpServletMappingWrapper.toJakartaHttpServletMapping(from.getHttpServletMapping());
+        }
+
+        @Override
+        public String getMethod() {
+            return from.getMethod();
+        }
+
+        @Override
+        public String getPathInfo() {
+            return from.getPathInfo();
+        }
+
+        @Override
+        public String getPathTranslated() {
+            return from.getPathTranslated();
+        }
+
+        @Override
+        public jakarta.servlet.http.PushBuilder newPushBuilder() {
+            // TODO implement this
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public String getContextPath() {
+            return from.getContextPath();
+        }
+
+        @Override
+        public String getQueryString() {
+            return from.getQueryString();
+        }
+
+        @Override
+        public String getRemoteUser() {
+            return from.getRemoteUser();
+        }
+
+        @Override
+        public boolean isUserInRole(String role) {
+            return from.isUserInRole(role);
+        }
+
+        @Override
+        public Principal getUserPrincipal() {
+            return from.getUserPrincipal();
+        }
+
+        @Override
+        public String getRequestedSessionId() {
+            return from.getRequestedSessionId();
+        }
+
+        @Override
+        public String getRequestURI() {
+            return from.getRequestURI();
+        }
+
+        @Override
+        public StringBuffer getRequestURL() {
+            return from.getRequestURL();
+        }
+
+        @Override
+        public String getServletPath() {
+            return from.getServletPath();
+        }
+
+        @Override
+        public jakarta.servlet.http.HttpSession getSession(boolean create) {
+            HttpSession session = from.getSession(create);
+            return session != null ? HttpSessionWrapper.toJakartaHttpSession(session) : null;
+        }
+
+        @Override
+        public jakarta.servlet.http.HttpSession getSession() {
+            HttpSession session = from.getSession();
+            return session != null ? HttpSessionWrapper.toJakartaHttpSession(session) : null;
+        }
+
+        @Override
+        public String changeSessionId() {
+            return from.changeSessionId();
+        }
+
+        @Override
+        public boolean isRequestedSessionIdValid() {
+            return from.isRequestedSessionIdValid();
+        }
+
+        @Override
+        public boolean isRequestedSessionIdFromCookie() {
+            return from.isRequestedSessionIdFromCookie();
+        }
+
+        @Override
+        public boolean isRequestedSessionIdFromURL() {
+            return from.isRequestedSessionIdFromURL();
+        }
+
+        @Override
+        public boolean isRequestedSessionIdFromUrl() {
+            return from.isRequestedSessionIdFromUrl();
+        }
+
+        @Override
+        public boolean authenticate(jakarta.servlet.http.HttpServletResponse response)
+                throws IOException, jakarta.servlet.ServletException {
+            try {
+                return from.authenticate(HttpServletResponseWrapper.fromJakartaHttpServletResponse(response));
+            } catch (ServletException e) {
+                throw ServletExceptionWrapper.toJakartaServletException(e);
+            }
+        }
+
+        @Override
+        public void login(String username, String password) throws jakarta.servlet.ServletException {
+            try {
+                from.login(username, password);
+            } catch (ServletException e) {
+                throw ServletExceptionWrapper.toJakartaServletException(e);
+            }
+        }
+
+        @Override
+        public void logout() throws jakarta.servlet.ServletException {
+            try {
+                from.logout();
+            } catch (ServletException e) {
+                throw ServletExceptionWrapper.toJakartaServletException(e);
+            }
+        }
+
+        @Override
+        public Collection<jakarta.servlet.http.Part> getParts() throws IOException, jakarta.servlet.ServletException {
+            try {
+                return from.getParts().stream().map(PartWrapper::toJakartaPart).collect(Collectors.toList());
+            } catch (ServletException e) {
+                throw ServletExceptionWrapper.toJakartaServletException(e);
+            }
+        }
+
+        @Override
+        public jakarta.servlet.http.Part getPart(String name) throws IOException, jakarta.servlet.ServletException {
+            try {
+                return PartWrapper.toJakartaPart(from.getPart(name));
+            } catch (ServletException e) {
+                throw ServletExceptionWrapper.toJakartaServletException(e);
+            }
+        }
+
+        @Override
+        public <T extends jakarta.servlet.http.HttpUpgradeHandler> T upgrade(Class<T> handlerClass) {
+            // TODO implement this
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Map<String, String> getTrailerFields() {
+            return from.getTrailerFields();
+        }
+
+        @Override
+        public boolean isTrailerFieldsReady() {
+            return from.isTrailerFieldsReady();
+        }
+
+        @Override
+        public HttpServletRequest toJavaxServletRequest() {
+            return from;
+        }
+    }
+
+    public interface JavaxHttpServletRequestWrapper {
+        jakarta.servlet.http.HttpServletRequest toJakartaHttpServletRequest();
+    }
+
+    private static class JavaxHttpServletRequestWrapperImpl
+            implements HttpServletRequest, ServletRequestWrapper.JavaxServletRequestWrapper {
+        private final jakarta.servlet.http.HttpServletRequest from;
+
+        public JavaxHttpServletRequestWrapperImpl(jakarta.servlet.http.HttpServletRequest from) {
+            this.from = Objects.requireNonNull(from);
+        }
+
+        @Override
+        public Object getAttribute(String name) {
+            return from.getAttribute(name);
+        }
+
+        @Override
+        public Enumeration<String> getAttributeNames() {
+            return from.getAttributeNames();
+        }
+
+        @Override
+        public String getCharacterEncoding() {
+            return from.getCharacterEncoding();
+        }
+
+        @Override
+        public void setCharacterEncoding(String env) throws UnsupportedEncodingException {
+            from.setCharacterEncoding(env);
+        }
+
+        @Override
+        public int getContentLength() {
+            return from.getContentLength();
+        }
+
+        @Override
+        public long getContentLengthLong() {
+            return from.getContentLengthLong();
+        }
+
+        @Override
+        public String getContentType() {
+            return from.getContentType();
+        }
+
+        @Override
+        public ServletInputStream getInputStream() throws IOException {
+            return ServletInputStreamWrapper.fromJakartaServletInputStream(from.getInputStream());
+        }
+
+        @Override
+        public String getParameter(String name) {
+            return from.getParameter(name);
+        }
+
+        @Override
+        public Enumeration<String> getParameterNames() {
+            return from.getParameterNames();
+        }
+
+        @Override
+        public String[] getParameterValues(String name) {
+            return from.getParameterValues(name);
+        }
+
+        @Override
+        public Map<String, String[]> getParameterMap() {
+            return from.getParameterMap();
+        }
+
+        @Override
+        public String getProtocol() {
+            return from.getProtocol();
+        }
+
+        @Override
+        public String getScheme() {
+            return from.getScheme();
+        }
+
+        @Override
+        public String getServerName() {
+            return from.getServerName();
+        }
+
+        @Override
+        public int getServerPort() {
+            return from.getServerPort();
+        }
+
+        @Override
+        public BufferedReader getReader() throws IOException {
+            return from.getReader();
+        }
+
+        @Override
+        public String getRemoteAddr() {
+            return from.getRemoteAddr();
+        }
+
+        @Override
+        public String getRemoteHost() {
+            return from.getRemoteHost();
+        }
+
+        @Override
+        public void setAttribute(String name, Object o) {
+            from.setAttribute(name, o);
+        }
+
+        @Override
+        public void removeAttribute(String name) {
+            from.removeAttribute(name);
+        }
+
+        @Override
+        public Locale getLocale() {
+            return from.getLocale();
+        }
+
+        @Override
+        public Enumeration<Locale> getLocales() {
+            return from.getLocales();
+        }
+
+        @Override
+        public boolean isSecure() {
+            return from.isSecure();
+        }
+
+        @Override
+        public RequestDispatcher getRequestDispatcher(String path) {
+            return RequestDispatcherWrapper.fromJakartaRequestDispatcher(from.getRequestDispatcher(path));
+        }
+
+        @Override
+        public String getRealPath(String path) {
+            return from.getRealPath(path);
+        }
+
+        @Override
+        public int getRemotePort() {
+            return from.getRemotePort();
+        }
+
+        @Override
+        public String getLocalName() {
+            return from.getLocalName();
+        }
+
+        @Override
+        public String getLocalAddr() {
+            return from.getLocalAddr();
+        }
+
+        @Override
+        public int getLocalPort() {
+            return from.getLocalPort();
+        }
+
+        @Override
+        public ServletContext getServletContext() {
+            return ServletContextWrapper.fromJakartServletContext(from.getServletContext());
+        }
+
+        @Override
+        public AsyncContext startAsync() {
+            return AsyncContextWrapper.fromJakartaAsyncContext(from.startAsync());
+        }
+
+        @Override
+        public AsyncContext startAsync(ServletRequest servletRequest, ServletResponse servletResponse) {
+            return AsyncContextWrapper.fromJakartaAsyncContext(from.startAsync(
+                    ServletRequestWrapper.toJakartaServletRequest(servletRequest),
+                    ServletResponseWrapper.toJakartaServletResponse(servletResponse)));
+        }
+
+        @Override
+        public boolean isAsyncStarted() {
+            return from.isAsyncStarted();
+        }
+
+        @Override
+        public boolean isAsyncSupported() {
+            return from.isAsyncSupported();
+        }
+
+        @Override
+        public AsyncContext getAsyncContext() {
+            return AsyncContextWrapper.fromJakartaAsyncContext(from.getAsyncContext());
+        }
+
+        @Override
+        public DispatcherType getDispatcherType() {
+            return DispatcherTypeWrapper.fromJakartaDispatcherType(from.getDispatcherType());
+        }
+
+        @Override
+        public String getAuthType() {
+            return from.getAuthType();
+        }
+
+        @Override
+        public Cookie[] getCookies() {
+            return Stream.of(from.getCookies())
+                    .map(CookieWrapper::fromJakartaServletHttpCookie)
+                    .toArray(Cookie[]::new);
+        }
+
+        @Override
+        public long getDateHeader(String name) {
+            return from.getDateHeader(name);
+        }
+
+        @Override
+        public String getHeader(String name) {
+            return from.getHeader(name);
+        }
+
+        @Override
+        public Enumeration<String> getHeaders(String name) {
+            return from.getHeaders(name);
+        }
+
+        @Override
+        public Enumeration<String> getHeaderNames() {
+            return from.getHeaderNames();
+        }
+
+        @Override
+        public int getIntHeader(String name) {
+            return from.getIntHeader(name);
+        }
+
+        @Override
+        public HttpServletMapping getHttpServletMapping() {
+            return HttpServletMappingWrapper.fromJakartaHttpServletMapping(from.getHttpServletMapping());
+        }
+
+        @Override
+        public String getMethod() {
+            return from.getMethod();
+        }
+
+        @Override
+        public String getPathInfo() {
+            return from.getPathInfo();
+        }
+
+        @Override
+        public String getPathTranslated() {
+            return from.getPathTranslated();
+        }
+
+        @Override
+        public PushBuilder newPushBuilder() {
+            // TODO implement this
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public String getContextPath() {
+            return from.getContextPath();
+        }
+
+        @Override
+        public String getQueryString() {
+            return from.getQueryString();
+        }
+
+        @Override
+        public String getRemoteUser() {
+            return from.getRemoteUser();
+        }
+
+        @Override
+        public boolean isUserInRole(String role) {
+            return from.isUserInRole(role);
+        }
+
+        @Override
+        public Principal getUserPrincipal() {
+            return from.getUserPrincipal();
+        }
+
+        @Override
+        public String getRequestedSessionId() {
+            return from.getRequestedSessionId();
+        }
+
+        @Override
+        public String getRequestURI() {
+            return from.getRequestURI();
+        }
+
+        @Override
+        public StringBuffer getRequestURL() {
+            return from.getRequestURL();
+        }
+
+        @Override
+        public String getServletPath() {
+            return from.getServletPath();
+        }
+
+        @Override
+        public HttpSession getSession(boolean create) {
+            jakarta.servlet.http.HttpSession session = from.getSession(create);
+            return session != null ? HttpSessionWrapper.fromJakartaHttpSession(session) : null;
+        }
+
+        @Override
+        public HttpSession getSession() {
+            jakarta.servlet.http.HttpSession session = from.getSession();
+            return session != null ? HttpSessionWrapper.fromJakartaHttpSession(session) : null;
+        }
+
+        @Override
+        public String changeSessionId() {
+            return from.changeSessionId();
+        }
+
+        @Override
+        public boolean isRequestedSessionIdValid() {
+            return from.isRequestedSessionIdValid();
+        }
+
+        @Override
+        public boolean isRequestedSessionIdFromCookie() {
+            return from.isRequestedSessionIdFromCookie();
+        }
+
+        @Override
+        public boolean isRequestedSessionIdFromURL() {
+            return from.isRequestedSessionIdFromURL();
+        }
+
+        @Override
+        public boolean isRequestedSessionIdFromUrl() {
+            return from.isRequestedSessionIdFromUrl();
+        }
+
+        @Override
+        public boolean authenticate(HttpServletResponse response) throws IOException, ServletException {
+            try {
+                return from.authenticate(HttpServletResponseWrapper.toJakartaHttpServletResponse(response));
+            } catch (jakarta.servlet.ServletException e) {
+                throw ServletExceptionWrapper.fromJakartaServletException(e);
+            }
+        }
+
+        @Override
+        public void login(String username, String password) throws ServletException {
+            try {
+                from.login(username, password);
+            } catch (jakarta.servlet.ServletException e) {
+                throw ServletExceptionWrapper.fromJakartaServletException(e);
+            }
+        }
+
+        @Override
+        public void logout() throws ServletException {
+            try {
+                from.logout();
+            } catch (jakarta.servlet.ServletException e) {
+                throw ServletExceptionWrapper.fromJakartaServletException(e);
+            }
+        }
+
+        @Override
+        public Collection<Part> getParts() throws IOException, ServletException {
+            try {
+                return from.getParts().stream()
+                        .map(PartWrapper::fromJakartaPart)
+                        .collect(Collectors.toList());
+            } catch (jakarta.servlet.ServletException e) {
+                throw ServletExceptionWrapper.fromJakartaServletException(e);
+            }
+        }
+
+        @Override
+        public Part getPart(String name) throws IOException, ServletException {
+            try {
+                return PartWrapper.fromJakartaPart(from.getPart(name));
+            } catch (jakarta.servlet.ServletException e) {
+                throw ServletExceptionWrapper.fromJakartaServletException(e);
+            }
+        }
+
+        @Override
+        public <T extends HttpUpgradeHandler> T upgrade(Class<T> handlerClass) {
+            // TODO implement this
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Map<String, String> getTrailerFields() {
+            return from.getTrailerFields();
+        }
+
+        @Override
+        public boolean isTrailerFieldsReady() {
+            return from.isTrailerFieldsReady();
+        }
+
+        @Override
+        public jakarta.servlet.http.HttpServletRequest toJakartaServletRequest() {
+            return from;
+        }
     }
 }

--- a/src/main/java/io/jenkins/servlet/http/HttpServletResponseWrapper.java
+++ b/src/main/java/io/jenkins/servlet/http/HttpServletResponseWrapper.java
@@ -1,6 +1,7 @@
 package io.jenkins.servlet.http;
 
 import io.jenkins.servlet.ServletOutputStreamWrapper;
+import io.jenkins.servlet.ServletResponseWrapper;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.Collection;
@@ -9,407 +10,462 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.function.Supplier;
 import javax.servlet.ServletOutputStream;
+import javax.servlet.ServletResponse;
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletResponse;
 
 public class HttpServletResponseWrapper {
     public static jakarta.servlet.http.HttpServletResponse toJakartaHttpServletResponse(HttpServletResponse from) {
-        Objects.requireNonNull(from);
-        return new jakarta.servlet.http.HttpServletResponse() {
-            @Override
-            public String getCharacterEncoding() {
-                return from.getCharacterEncoding();
-            }
-
-            @Override
-            public String getContentType() {
-                return from.getContentType();
-            }
-
-            @Override
-            public jakarta.servlet.ServletOutputStream getOutputStream() throws IOException {
-                return ServletOutputStreamWrapper.toJakartaServletOutputStream(from.getOutputStream());
-            }
-
-            @Override
-            public PrintWriter getWriter() throws IOException {
-                return from.getWriter();
-            }
-
-            @Override
-            public void setCharacterEncoding(String charset) {
-                from.setCharacterEncoding(charset);
-            }
-
-            @Override
-            public void setContentLength(int len) {
-                from.setContentLength(len);
-            }
-
-            @Override
-            public void setContentLengthLong(long len) {
-                from.setContentLengthLong(len);
-            }
-
-            @Override
-            public void setContentType(String type) {
-                from.setContentType(type);
-            }
-
-            @Override
-            public void setBufferSize(int size) {
-                from.setBufferSize(size);
-            }
-
-            @Override
-            public int getBufferSize() {
-                return from.getBufferSize();
-            }
-
-            @Override
-            public void flushBuffer() throws IOException {
-                from.flushBuffer();
-            }
-
-            @Override
-            public void resetBuffer() {
-                from.resetBuffer();
-            }
-
-            @Override
-            public boolean isCommitted() {
-                return from.isCommitted();
-            }
-
-            @Override
-            public void reset() {
-                from.reset();
-            }
-
-            @Override
-            public void setLocale(Locale loc) {
-                from.setLocale(loc);
-            }
-
-            @Override
-            public Locale getLocale() {
-                return from.getLocale();
-            }
-
-            @Override
-            public void addCookie(jakarta.servlet.http.Cookie cookie) {
-                from.addCookie(CookieWrapper.fromJakartaServletHttpCookie(cookie));
-            }
-
-            @Override
-            public boolean containsHeader(String name) {
-                return from.containsHeader(name);
-            }
-
-            @Override
-            public String encodeURL(String url) {
-                return from.encodeURL(url);
-            }
-
-            @Override
-            public String encodeRedirectURL(String url) {
-                return from.encodeRedirectURL(url);
-            }
-
-            @Override
-            public String encodeUrl(String url) {
-                return from.encodeUrl(url);
-            }
-
-            @Override
-            public String encodeRedirectUrl(String url) {
-                return from.encodeRedirectUrl(url);
-            }
-
-            @Override
-            public void sendError(int sc, String msg) throws IOException {
-                from.sendError(sc, msg);
-            }
-
-            @Override
-            public void sendError(int sc) throws IOException {
-                from.sendError(sc);
-            }
-
-            @Override
-            public void sendRedirect(String location) throws IOException {
-                from.sendRedirect(location);
-            }
-
-            @Override
-            public void setDateHeader(String name, long date) {
-                from.setDateHeader(name, date);
-            }
-
-            @Override
-            public void addDateHeader(String name, long date) {
-                from.addDateHeader(name, date);
-            }
-
-            @Override
-            public void setHeader(String name, String value) {
-                from.setHeader(name, value);
-            }
-
-            @Override
-            public void addHeader(String name, String value) {
-                from.addHeader(name, value);
-            }
-
-            @Override
-            public void setIntHeader(String name, int value) {
-                from.setIntHeader(name, value);
-            }
-
-            @Override
-            public void addIntHeader(String name, int value) {
-                from.addIntHeader(name, value);
-            }
-
-            @Override
-            public void setStatus(int sc) {
-                from.setStatus(sc);
-            }
-
-            @Override
-            public void setStatus(int sc, String sm) {
-                from.setStatus(sc, sm);
-            }
-
-            @Override
-            public int getStatus() {
-                return from.getStatus();
-            }
-
-            @Override
-            public String getHeader(String name) {
-                return from.getHeader(name);
-            }
-
-            @Override
-            public Collection<String> getHeaders(String name) {
-                return from.getHeaders(name);
-            }
-
-            @Override
-            public Collection<String> getHeaderNames() {
-                return from.getHeaderNames();
-            }
-
-            @Override
-            public void setTrailerFields(Supplier<Map<String, String>> supplier) {
-                from.setTrailerFields(supplier);
-            }
-
-            @Override
-            public Supplier<Map<String, String>> getTrailerFields() {
-                return from.getTrailerFields();
-            }
-        };
+        if (from instanceof JavaxHttpServletResponseWrapper javax) {
+            return javax.toJakartaHttpServletResponse();
+        }
+        return new JakartaHttpServletResponseWrapperImpl(from);
     }
 
     public static HttpServletResponse fromJakartaHttpServletResponse(jakarta.servlet.http.HttpServletResponse from) {
-        Objects.requireNonNull(from);
-        return new HttpServletResponse() {
-            @Override
-            public String getCharacterEncoding() {
-                return from.getCharacterEncoding();
-            }
+        if (from instanceof JakartaHttpServletResponseWrapper jakarta) {
+            return jakarta.toJavaxHttpServletResponse();
+        }
+        return new JavaxHttpServletResponseWrapperImpl(from);
+    }
 
-            @Override
-            public String getContentType() {
-                return from.getContentType();
-            }
+    public interface JakartaHttpServletResponseWrapper {
+        HttpServletResponse toJavaxHttpServletResponse();
+    }
 
-            @Override
-            public ServletOutputStream getOutputStream() throws IOException {
-                return ServletOutputStreamWrapper.fromJakartaServletOutputStream(from.getOutputStream());
-            }
+    private static class JakartaHttpServletResponseWrapperImpl
+            implements jakarta.servlet.http.HttpServletResponse,
+                    ServletResponseWrapper.JakartaServletResponseWrapper,
+                    JakartaHttpServletResponseWrapper {
+        private final HttpServletResponse from;
 
-            @Override
-            public PrintWriter getWriter() throws IOException {
-                return from.getWriter();
-            }
+        public JakartaHttpServletResponseWrapperImpl(HttpServletResponse from) {
+            this.from = Objects.requireNonNull(from);
+        }
 
-            @Override
-            public void setCharacterEncoding(String charset) {
-                from.setCharacterEncoding(charset);
-            }
+        @Override
+        public String getCharacterEncoding() {
+            return from.getCharacterEncoding();
+        }
 
-            @Override
-            public void setContentLength(int len) {
-                from.setContentLength(len);
-            }
+        @Override
+        public String getContentType() {
+            return from.getContentType();
+        }
 
-            @Override
-            public void setContentLengthLong(long len) {
-                from.setContentLengthLong(len);
-            }
+        @Override
+        public jakarta.servlet.ServletOutputStream getOutputStream() throws IOException {
+            return ServletOutputStreamWrapper.toJakartaServletOutputStream(from.getOutputStream());
+        }
 
-            @Override
-            public void setContentType(String type) {
-                from.setContentType(type);
-            }
+        @Override
+        public PrintWriter getWriter() throws IOException {
+            return from.getWriter();
+        }
 
-            @Override
-            public void setBufferSize(int size) {
-                from.setBufferSize(size);
-            }
+        @Override
+        public void setCharacterEncoding(String charset) {
+            from.setCharacterEncoding(charset);
+        }
 
-            @Override
-            public int getBufferSize() {
-                return from.getBufferSize();
-            }
+        @Override
+        public void setContentLength(int len) {
+            from.setContentLength(len);
+        }
 
-            @Override
-            public void flushBuffer() throws IOException {
-                from.flushBuffer();
-            }
+        @Override
+        public void setContentLengthLong(long len) {
+            from.setContentLengthLong(len);
+        }
 
-            @Override
-            public void resetBuffer() {
-                from.resetBuffer();
-            }
+        @Override
+        public void setContentType(String type) {
+            from.setContentType(type);
+        }
 
-            @Override
-            public boolean isCommitted() {
-                return from.isCommitted();
-            }
+        @Override
+        public void setBufferSize(int size) {
+            from.setBufferSize(size);
+        }
 
-            @Override
-            public void reset() {
-                from.reset();
-            }
+        @Override
+        public int getBufferSize() {
+            return from.getBufferSize();
+        }
 
-            @Override
-            public void setLocale(Locale loc) {
-                from.setLocale(loc);
-            }
+        @Override
+        public void flushBuffer() throws IOException {
+            from.flushBuffer();
+        }
 
-            @Override
-            public Locale getLocale() {
-                return from.getLocale();
-            }
+        @Override
+        public void resetBuffer() {
+            from.resetBuffer();
+        }
 
-            @Override
-            public void addCookie(Cookie cookie) {
-                from.addCookie(CookieWrapper.toJakartaServletHttpCookie(cookie));
-            }
+        @Override
+        public boolean isCommitted() {
+            return from.isCommitted();
+        }
 
-            @Override
-            public boolean containsHeader(String name) {
-                return from.containsHeader(name);
-            }
+        @Override
+        public void reset() {
+            from.reset();
+        }
 
-            @Override
-            public String encodeURL(String url) {
-                return from.encodeURL(url);
-            }
+        @Override
+        public void setLocale(Locale loc) {
+            from.setLocale(loc);
+        }
 
-            @Override
-            public String encodeRedirectURL(String url) {
-                return from.encodeRedirectURL(url);
-            }
+        @Override
+        public Locale getLocale() {
+            return from.getLocale();
+        }
 
-            @Override
-            public String encodeUrl(String url) {
-                return from.encodeUrl(url);
-            }
+        @Override
+        public void addCookie(jakarta.servlet.http.Cookie cookie) {
+            from.addCookie(CookieWrapper.fromJakartaServletHttpCookie(cookie));
+        }
 
-            @Override
-            public String encodeRedirectUrl(String url) {
-                return from.encodeRedirectUrl(url);
-            }
+        @Override
+        public boolean containsHeader(String name) {
+            return from.containsHeader(name);
+        }
 
-            @Override
-            public void sendError(int sc, String msg) throws IOException {
-                from.sendError(sc, msg);
-            }
+        @Override
+        public String encodeURL(String url) {
+            return from.encodeURL(url);
+        }
 
-            @Override
-            public void sendError(int sc) throws IOException {
-                from.sendError(sc);
-            }
+        @Override
+        public String encodeRedirectURL(String url) {
+            return from.encodeRedirectURL(url);
+        }
 
-            @Override
-            public void sendRedirect(String location) throws IOException {
-                from.sendRedirect(location);
-            }
+        @Override
+        public String encodeUrl(String url) {
+            return from.encodeUrl(url);
+        }
 
-            @Override
-            public void setDateHeader(String name, long date) {
-                from.setDateHeader(name, date);
-            }
+        @Override
+        public String encodeRedirectUrl(String url) {
+            return from.encodeRedirectUrl(url);
+        }
 
-            @Override
-            public void addDateHeader(String name, long date) {
-                from.addDateHeader(name, date);
-            }
+        @Override
+        public void sendError(int sc, String msg) throws IOException {
+            from.sendError(sc, msg);
+        }
 
-            @Override
-            public void setHeader(String name, String value) {
-                from.setHeader(name, value);
-            }
+        @Override
+        public void sendError(int sc) throws IOException {
+            from.sendError(sc);
+        }
 
-            @Override
-            public void addHeader(String name, String value) {
-                from.addHeader(name, value);
-            }
+        @Override
+        public void sendRedirect(String location) throws IOException {
+            from.sendRedirect(location);
+        }
 
-            @Override
-            public void setIntHeader(String name, int value) {
-                from.setIntHeader(name, value);
-            }
+        @Override
+        public void setDateHeader(String name, long date) {
+            from.setDateHeader(name, date);
+        }
 
-            @Override
-            public void addIntHeader(String name, int value) {
-                from.addIntHeader(name, value);
-            }
+        @Override
+        public void addDateHeader(String name, long date) {
+            from.addDateHeader(name, date);
+        }
 
-            @Override
-            public void setStatus(int sc) {
-                from.setStatus(sc);
-            }
+        @Override
+        public void setHeader(String name, String value) {
+            from.setHeader(name, value);
+        }
 
-            @Override
-            public void setStatus(int sc, String sm) {
-                from.setStatus(sc, sm);
-            }
+        @Override
+        public void addHeader(String name, String value) {
+            from.addHeader(name, value);
+        }
 
-            @Override
-            public int getStatus() {
-                return from.getStatus();
-            }
+        @Override
+        public void setIntHeader(String name, int value) {
+            from.setIntHeader(name, value);
+        }
 
-            @Override
-            public String getHeader(String name) {
-                return from.getHeader(name);
-            }
+        @Override
+        public void addIntHeader(String name, int value) {
+            from.addIntHeader(name, value);
+        }
 
-            @Override
-            public Collection<String> getHeaders(String name) {
-                return from.getHeaders(name);
-            }
+        @Override
+        public void setStatus(int sc) {
+            from.setStatus(sc);
+        }
 
-            @Override
-            public Collection<String> getHeaderNames() {
-                return from.getHeaderNames();
-            }
+        @Override
+        public void setStatus(int sc, String sm) {
+            from.setStatus(sc, sm);
+        }
 
-            @Override
-            public void setTrailerFields(Supplier<Map<String, String>> supplier) {
-                from.setTrailerFields(supplier);
-            }
+        @Override
+        public int getStatus() {
+            return from.getStatus();
+        }
 
-            @Override
-            public Supplier<Map<String, String>> getTrailerFields() {
-                return from.getTrailerFields();
-            }
-        };
+        @Override
+        public String getHeader(String name) {
+            return from.getHeader(name);
+        }
+
+        @Override
+        public Collection<String> getHeaders(String name) {
+            return from.getHeaders(name);
+        }
+
+        @Override
+        public Collection<String> getHeaderNames() {
+            return from.getHeaderNames();
+        }
+
+        @Override
+        public void setTrailerFields(Supplier<Map<String, String>> supplier) {
+            from.setTrailerFields(supplier);
+        }
+
+        @Override
+        public Supplier<Map<String, String>> getTrailerFields() {
+            return from.getTrailerFields();
+        }
+
+        @Override
+        public ServletResponse toJavaxServletResponse() {
+            return from;
+        }
+
+        @Override
+        public HttpServletResponse toJavaxHttpServletResponse() {
+            return from;
+        }
+    }
+
+    public interface JavaxHttpServletResponseWrapper {
+        jakarta.servlet.http.HttpServletResponse toJakartaHttpServletResponse();
+    }
+
+    private static class JavaxHttpServletResponseWrapperImpl
+            implements HttpServletResponse,
+                    ServletResponseWrapper.JavaxServletResponseWrapper,
+                    JavaxHttpServletResponseWrapper {
+        private final jakarta.servlet.http.HttpServletResponse from;
+
+        public JavaxHttpServletResponseWrapperImpl(jakarta.servlet.http.HttpServletResponse from) {
+            this.from = Objects.requireNonNull(from);
+        }
+
+        @Override
+        public String getCharacterEncoding() {
+            return from.getCharacterEncoding();
+        }
+
+        @Override
+        public String getContentType() {
+            return from.getContentType();
+        }
+
+        @Override
+        public ServletOutputStream getOutputStream() throws IOException {
+            return ServletOutputStreamWrapper.fromJakartaServletOutputStream(from.getOutputStream());
+        }
+
+        @Override
+        public PrintWriter getWriter() throws IOException {
+            return from.getWriter();
+        }
+
+        @Override
+        public void setCharacterEncoding(String charset) {
+            from.setCharacterEncoding(charset);
+        }
+
+        @Override
+        public void setContentLength(int len) {
+            from.setContentLength(len);
+        }
+
+        @Override
+        public void setContentLengthLong(long len) {
+            from.setContentLengthLong(len);
+        }
+
+        @Override
+        public void setContentType(String type) {
+            from.setContentType(type);
+        }
+
+        @Override
+        public void setBufferSize(int size) {
+            from.setBufferSize(size);
+        }
+
+        @Override
+        public int getBufferSize() {
+            return from.getBufferSize();
+        }
+
+        @Override
+        public void flushBuffer() throws IOException {
+            from.flushBuffer();
+        }
+
+        @Override
+        public void resetBuffer() {
+            from.resetBuffer();
+        }
+
+        @Override
+        public boolean isCommitted() {
+            return from.isCommitted();
+        }
+
+        @Override
+        public void reset() {
+            from.reset();
+        }
+
+        @Override
+        public void setLocale(Locale loc) {
+            from.setLocale(loc);
+        }
+
+        @Override
+        public Locale getLocale() {
+            return from.getLocale();
+        }
+
+        @Override
+        public void addCookie(Cookie cookie) {
+            from.addCookie(CookieWrapper.toJakartaServletHttpCookie(cookie));
+        }
+
+        @Override
+        public boolean containsHeader(String name) {
+            return from.containsHeader(name);
+        }
+
+        @Override
+        public String encodeURL(String url) {
+            return from.encodeURL(url);
+        }
+
+        @Override
+        public String encodeRedirectURL(String url) {
+            return from.encodeRedirectURL(url);
+        }
+
+        @Override
+        public String encodeUrl(String url) {
+            return from.encodeUrl(url);
+        }
+
+        @Override
+        public String encodeRedirectUrl(String url) {
+            return from.encodeRedirectUrl(url);
+        }
+
+        @Override
+        public void sendError(int sc, String msg) throws IOException {
+            from.sendError(sc, msg);
+        }
+
+        @Override
+        public void sendError(int sc) throws IOException {
+            from.sendError(sc);
+        }
+
+        @Override
+        public void sendRedirect(String location) throws IOException {
+            from.sendRedirect(location);
+        }
+
+        @Override
+        public void setDateHeader(String name, long date) {
+            from.setDateHeader(name, date);
+        }
+
+        @Override
+        public void addDateHeader(String name, long date) {
+            from.addDateHeader(name, date);
+        }
+
+        @Override
+        public void setHeader(String name, String value) {
+            from.setHeader(name, value);
+        }
+
+        @Override
+        public void addHeader(String name, String value) {
+            from.addHeader(name, value);
+        }
+
+        @Override
+        public void setIntHeader(String name, int value) {
+            from.setIntHeader(name, value);
+        }
+
+        @Override
+        public void addIntHeader(String name, int value) {
+            from.addIntHeader(name, value);
+        }
+
+        @Override
+        public void setStatus(int sc) {
+            from.setStatus(sc);
+        }
+
+        @Override
+        public void setStatus(int sc, String sm) {
+            from.setStatus(sc, sm);
+        }
+
+        @Override
+        public int getStatus() {
+            return from.getStatus();
+        }
+
+        @Override
+        public String getHeader(String name) {
+            return from.getHeader(name);
+        }
+
+        @Override
+        public Collection<String> getHeaders(String name) {
+            return from.getHeaders(name);
+        }
+
+        @Override
+        public Collection<String> getHeaderNames() {
+            return from.getHeaderNames();
+        }
+
+        @Override
+        public void setTrailerFields(Supplier<Map<String, String>> supplier) {
+            from.setTrailerFields(supplier);
+        }
+
+        @Override
+        public Supplier<Map<String, String>> getTrailerFields() {
+            return from.getTrailerFields();
+        }
+
+        @Override
+        public jakarta.servlet.ServletResponse toJakartaServletResponse() {
+            return from;
+        }
+
+        @Override
+        public jakarta.servlet.http.HttpServletResponse toJakartaHttpServletResponse() {
+            return from;
+        }
     }
 }


### PR DESCRIPTION
#10 broke the ability to round-trip servlet requests back and forth between wrapper objects. This PR restores this capability, at least for the main 4 types. I will think more about the naming of this and try to come up with a cleaner implementation that can be generalized to all types, but for now this restores the status quo prior to #10.

### Testing done

`hudson.plugins.sshslaves.verifiers.TrustHostKeyActionTest#testSubmitNotAuthorised` started failing after #10 and passes with this PR and the corresponding Stapler/core changes.